### PR TITLE
Removed LDO token from Lido reward tokens

### DIFF
--- a/src/ethereum/lido/contracts.ts
+++ b/src/ethereum/lido/contracts.ts
@@ -7,7 +7,7 @@ const contracts = {
       pool: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
       lpToken: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
       tokens: ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
-      rewardTokens: ["0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"],
+      rewardTokens: [],
       swap: "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022",
     },
   },


### PR DESCRIPTION
Fixes #32 

Removed LDO token address from Lido pool's rewards since LDO is only a governance token and it is not distributed after depositing.

#### PR Checklist

- [ ] Tests
